### PR TITLE
possible fix for java.lang.IndexOutOfBoundsException

### DIFF
--- a/recyclerdelegates/src/main/java/it/bienkowski/recyclerdelegates/DelegatingRecyclerAdapter.kt
+++ b/recyclerdelegates/src/main/java/it/bienkowski/recyclerdelegates/DelegatingRecyclerAdapter.kt
@@ -11,12 +11,16 @@ class DelegatingRecyclerAdapter<I : Any>(
     private val manager: RecyclerDelegateManager<I>
 ) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
-    val items: MutableList<I> = mutableListOf()
+    private var mutableItems: List<I> = listOf()
+
+    val items : List<I>
+    get() = mutableItems
+
 
     fun submitList(newItems: List<I>) {
-        DiffUtil.calculateDiff(DelegatingDiffUtilCallback(manager, items, newItems)).dispatchUpdatesTo(this)
-        items.clear()
-        items.addAll(newItems)
+        val oldItems = mutableItems
+        mutableItems = newItems
+        DiffUtil.calculateDiff(DelegatingDiffUtilCallback(manager, oldItems, newItems)).dispatchUpdatesTo(this)
     }
 
     @Deprecated("use submitList instead")


### PR DESCRIPTION
Possible fix for java.lang.IndexOutOfBoundsException: Inconsistency detected. Invalid view holder adapter position